### PR TITLE
Bug: Padding & Margin not used during initialization

### DIFF
--- a/SexyTooltip/SexyTooltip.m
+++ b/SexyTooltip/SexyTooltip.m
@@ -86,6 +86,9 @@ CGRectFromEdgeInsets(CGRect rect, UIEdgeInsets edgeInsets) {
         label.numberOfLines = 0;
         [label sizeToFit];
         self.contentView = label;
+        
+        self.padding = padding;
+        self.margin = margin;
     }
     return self;
 }


### PR DESCRIPTION
Fixed `initWithAttributedString:sizedToView:withPadding:andMargin:`
bug: Padding & margin were not being applied to the tooltip.
